### PR TITLE
Add build arguments for Alpine and OpenSSL versions in Docker setup

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -49,3 +49,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
+          build-args: |
+            ALPINE_VERSION=3.21.3
+            OPENSSL_VERSION=3.3.3-r0
+          

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM alpine:3.21.3
+ARG ALPINE_VERSION=3.21.3
+FROM alpine:${ALPINE_VERSION}
 
 # Install openssl and bash for better scripting
-RUN apk add --no-cache openssl bash
+ARG OPENSSL_VERSION=3.3.3-r0
+RUN apk add --no-cache openssl=${OPENSSL_VERSION} bash
 
 # Set working directory
 WORKDIR /app

--- a/docker/README.md
+++ b/docker/README.md
@@ -131,3 +131,31 @@ docker exec -it key2pfx-dev bash
 
 cd /certs
 ```
+
+# Build with custom version  
+
+Docker compose
+
+```yaml
+key2pfx:
+    container_name: key2pfx-dev
+    # entrypoint: ["/bin/bash", "-c"]
+    # command: ["sleep infinity"]
+    image: key2pfx:latest
+    build:
+      context: ../
+      dockerfile: ./Dockerfile
+      args:
+        ALPINE_VERSION: 3.21.3
+        OPENSSL_VERSION: 3.3.3-r0
+```
+
+```bash
+docker compose -f docker-compose-dev.yaml build --no-cache
+```
+
+Docker
+
+```bash
+docker build --build-arg ALPINE_VERSION=3.21.3 --build-arg OPENSSL_VERSION=3.3.3-r0 -t key2pfx:dev .
+```

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -7,6 +7,9 @@ services:
     build:
       context: ../
       dockerfile: ./Dockerfile
+      args:
+        ALPINE_VERSION: 3.21.3
+        OPENSSL_VERSION: 3.3.3-r0
     environment:
       - CRT=/certs/tls.crt
       - KEY=/certs/tls.key


### PR DESCRIPTION
## ✨ What's New

- Introduced build arguments `ALPINE_VERSION` and `OPENSSL_VERSION` to the Docker setup, allowing customization of the Alpine Linux and OpenSSL versions used during the build process.

## 🛠️ Changes Made

- **Dockerfile**: Added `ARG` directives for `ALPINE_VERSION` and `OPENSSL_VERSION`, enabling dynamic specification of these versions at build time.
- **docker-compose.yaml**: Updated to pass the new build arguments to the Docker build context, ensuring that the specified versions are utilized during the build.

## 📝 Usage

To build the Docker image with specific versions of Alpine and OpenSSL, use the following command:

```bash
docker build --build-arg ALPINE_VERSION=<desired-alpine-version> --build-arg OPENSSL_VERSION=<desired-openssl-version> -t your-image-name .
```

Replace `<desired-alpine-version>` and `<desired-openssl-version>` with the versions you wish to use.

✅ Testing
- Verified that the Docker image builds successfully with different combinations of Alpine and OpenSSL versions by specifying the build arguments during the build process.
- Confirmed that the application functions correctly within the container when built with various versions.

📚 References
- [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages): For available Alpine package versions.
- [Alpine Version in Docker Hub](https://hub.docker.com/_/alpine): For available Alpine versions.
- [OpenSSL Releases](https://www.openssl.org/source/): For available OpenSSL versions.
